### PR TITLE
When starting the service, don't exit on failed image manifest

### DIFF
--- a/lib/Pulse.js
+++ b/lib/Pulse.js
@@ -122,7 +122,18 @@ class Pulse {
 
     for(const image of images_list) {
       log.info("Checking image", image);
-      await this.registry_auth.get_image_manifest(image);
+      try {
+        await this.registry_auth.get_image_manifest(image);
+      }
+      catch(err) {
+        Object.keys(this.tasks)
+          .filter((task_name) => image === this.tasks[task_name].job_specs.image)
+          .forEach(task_name => {
+            log.error(`Failure to get the image manifest, disabled task ${task_name}: `, err);
+            this.tasks[task_name].plan = false;
+            this.tasks[task_name].err = String(err);
+          });
+      }
     }
   }
 


### PR DESCRIPTION
Allow failed manifest fetches to continue booting Pulse, but disable these tasks